### PR TITLE
Mobile tests

### DIFF
--- a/commons-module/src/test/java/ru/qatools/school/mobiletests/MetroAppTests.java
+++ b/commons-module/src/test/java/ru/qatools/school/mobiletests/MetroAppTests.java
@@ -1,0 +1,36 @@
+package ru.qatools.school.mobiletests;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import ru.qatools.school.rules.MobileDriverRule;
+import ru.qatools.school.steps.mobilesteps.MetroAppSteps;
+import ru.yandex.qatools.allure.annotations.Title;
+
+/**
+ * @author gladnik (Nikolai Gladkov)
+ */
+public class MetroAppTests {
+
+    private static final String FIRST_STATION = "Arbatskaya";
+    private static final String SECOND_STATION = "Borisovo";
+    private static final int MIN_TIME = 10;
+
+    private MetroAppSteps metroSteps;
+
+    @Rule
+    public MobileDriverRule androidDriverRule = new MobileDriverRule();
+
+    @Before
+    public void initSteps() {
+        metroSteps = new MetroAppSteps(androidDriverRule.getDriver());
+    }
+
+    @Test
+    @Title("Время в пути между станциями должно быть больше минимального")
+    public void shouldGetRouteExceedingMinTime() {
+        metroSteps.setRoute(FIRST_STATION, SECOND_STATION);
+        metroSteps.shouldSeeTravelTimeGreaterThan(MIN_TIME);
+    }
+
+}

--- a/steps-module/src/main/java/ru/qatools/school/rules/MobileDriverRule.java
+++ b/steps-module/src/main/java/ru/qatools/school/rules/MobileDriverRule.java
@@ -1,0 +1,33 @@
+package ru.qatools.school.rules;
+
+import org.junit.rules.ExternalResource;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.net.URL;
+
+/**
+ * @author gladnik (Nikolai Gladkov)
+ */
+public class MobileDriverRule extends ExternalResource {
+
+    private RemoteWebDriver driver;
+
+    protected void before() throws Throwable {
+        DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
+        desiredCapabilities.setCapability("platformName", "Android");
+        desiredCapabilities.setCapability("deviceName", "Android");
+        desiredCapabilities.setCapability("app", "http://autoschool.github.io/files/ya-metro.apk");
+        desiredCapabilities.setCapability("appWaitActivity", "ru.yandex.metro.MainActivity");
+        driver = new RemoteWebDriver(new URL("http://127.0.0.1:4723/wd/hub"), desiredCapabilities);
+    }
+
+    protected void after() {
+        driver.quit();
+    }
+
+    public RemoteWebDriver getDriver() {
+        return driver;
+    }
+
+}

--- a/steps-module/src/main/java/ru/qatools/school/screens/MainScreen.java
+++ b/steps-module/src/main/java/ru/qatools/school/screens/MainScreen.java
@@ -1,0 +1,45 @@
+package ru.qatools.school.screens;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import ru.yandex.qatools.htmlelements.annotations.Name;
+import ru.yandex.qatools.htmlelements.element.HtmlElement;
+import ru.yandex.qatools.htmlelements.loader.decorator.HtmlElementDecorator;
+import ru.yandex.qatools.htmlelements.loader.decorator.HtmlElementLocatorFactory;
+
+/**
+ * @author gladnik (Nikolai Gladkov)
+ */
+public class MainScreen {
+
+    @Name("Поле ввода начальной станции")
+    @FindBy(id = "ru.yandex.metro:id/tv_from_name")
+    private HtmlElement tvFromName;
+
+    @Name("Поле ввода конечной станции")
+    @FindBy(id = "ru.yandex.metro:id/tv_to_name")
+    private HtmlElement tvToName;
+
+    @Name("Время в пути")
+    @FindBy(id = "ru.yandex.metro:id/tv_time")
+    private HtmlElement tvTime;
+
+
+    public MainScreen(WebDriver driver) {
+        PageFactory.initElements(new HtmlElementDecorator(new HtmlElementLocatorFactory(driver)), this);
+    }
+
+    public HtmlElement tvFromName() {
+        return tvFromName;
+    }
+
+    public HtmlElement tvToName() {
+        return tvToName;
+    }
+
+    public HtmlElement tvTime() {
+        return tvTime;
+    }
+
+}

--- a/steps-module/src/main/java/ru/qatools/school/screens/SelectStationScreen.java
+++ b/steps-module/src/main/java/ru/qatools/school/screens/SelectStationScreen.java
@@ -1,0 +1,46 @@
+package ru.qatools.school.screens;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import ru.yandex.qatools.htmlelements.annotations.Name;
+import ru.yandex.qatools.htmlelements.element.HtmlElement;
+import ru.yandex.qatools.htmlelements.loader.decorator.HtmlElementDecorator;
+import ru.yandex.qatools.htmlelements.loader.decorator.HtmlElementLocatorFactory;
+
+import java.util.List;
+
+/**
+ * @author gladnik (Nikolai Gladkov)
+ */
+public class SelectStationScreen {
+
+    @Name("Поле ввода для поиска станции")
+    @FindBy(id = "ru.yandex.metro:id/filterTextId")
+    private HtmlElement filterTextId;
+
+    @Name("Названия найденных станций")
+    @FindBy(id = "ru.yandex.metro:id/txtStationName")
+    private List<HtmlElement> foundStations;
+
+    @Name("Название первой из найденных станций")
+    private HtmlElement firstStation;
+
+
+    public SelectStationScreen(WebDriver driver) {
+        PageFactory.initElements(new HtmlElementDecorator(new HtmlElementLocatorFactory(driver)), this);
+    }
+
+    public HtmlElement filterTextId() {
+        return filterTextId;
+    }
+
+    public List<HtmlElement> foundStations() {
+        return foundStations;
+    }
+
+    public HtmlElement firstStation() {
+        firstStation = foundStations.get(0);
+        return firstStation;
+    }
+}

--- a/steps-module/src/main/java/ru/qatools/school/steps/mobilesteps/MetroAppSteps.java
+++ b/steps-module/src/main/java/ru/qatools/school/steps/mobilesteps/MetroAppSteps.java
@@ -1,0 +1,74 @@
+package ru.qatools.school.steps.mobilesteps;
+
+import org.openqa.selenium.WebDriver;
+import ru.qatools.school.screens.MainScreen;
+import ru.qatools.school.screens.SelectStationScreen;
+import ru.yandex.qatools.allure.annotations.Step;
+import ru.yandex.qatools.htmlelements.element.HtmlElement;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author gladnik (Nikolai Gladkov)
+ */
+public class MetroAppSteps {
+
+    private WebDriver driver;
+
+    public MetroAppSteps(WebDriver driver) {
+        this.driver = driver;
+    }
+
+    @Step("Тапаем по [{0}]")
+    public static void tapOn(HtmlElement element) {
+        element.click();
+    }
+
+    @Step("Вводим «{1}» в «{0}»")
+    public static void sendText(HtmlElement element, String text) {
+        element.sendKeys(text);
+    }
+
+    @Step("Меняем станцию отправления на «{0}»")
+    public void changeDepartureStationBySelectScreen(String newStationName) {
+        tapOn(onMainScreen().tvFromName());
+        sendText(onSelectStationScreen().filterTextId(), newStationName);
+        tapOn(onSelectStationScreen().firstStation());
+    }
+
+    @Step("Меняем станцию назанчения на «{0}»")
+    public void changeDestinationStationBySelectScreen(String newStationName) {
+        tapOn(onMainScreen().tvToName());
+        sendText(onSelectStationScreen().filterTextId(), newStationName);
+        tapOn(onSelectStationScreen().firstStation());
+    }
+
+    @Step("Прокладываем маршрут от «{0}» к «{1}»")
+    public void setRoute(String fromStation, String toStation) {
+        changeDepartureStationBySelectScreen(fromStation);
+        changeDestinationStationBySelectScreen(toStation);
+    }
+
+    @Step("Время в пути должно быть больше {0} минут")
+    public void shouldSeeTravelTimeGreaterThan(int timeInMinutes) {
+        int travelDurationInMinutes;
+        String[] timeDescription = onMainScreen().tvTime().getText().trim().split(" ");
+        if (timeDescription.length == 2) {
+            travelDurationInMinutes = Integer.parseInt(timeDescription[0]);
+        } else {
+            travelDurationInMinutes = Integer.parseInt(timeDescription[0]) * 60 + Integer.parseInt(timeDescription[2]);
+        }
+
+        assertThat("Время в пути должно быть больше", travelDurationInMinutes, greaterThan(timeInMinutes));
+    }
+
+    private MainScreen onMainScreen() {
+        return new MainScreen(driver);
+    }
+
+    private SelectStationScreen onSelectStationScreen() {
+        return new SelectStationScreen(driver);
+    }
+
+}


### PR DESCRIPTION
### Баг в Яндекс.Метро:

Предлагается маршрут без пересадки через разветвление Арбатско-Филёвской линии 
1. Выбираем станцию отправления "Выставочная" или "Международная"
2. Выбираем станцию назначения "Студенческая" или любую другую в направлении станции "Кунцевская"

Получаем маршрут между выбранными станциями без пересадки на станции "Киевская". Такой маршрут невозможен, поскольку поезда со станции "Международная" идут только в направлении станции "Арбатская".
Аналогичная ситуация возникает при построении маршрута в обратном направлении: предлагается маршрут без пересадок от станции "Кунцевская" до станции "Международная", что также неправильно.

![Screenshot](http://savepic.ru/9799526.png)
